### PR TITLE
Fixed typo in variable assignment of ParseBuildRateFormula()

### DIFF
--- a/Kerbal_Construction_Time/KCT_MathParsing.cs
+++ b/Kerbal_Construction_Time/KCT_MathParsing.cs
@@ -63,7 +63,7 @@ namespace KerbalConstructionTime
             }
             upgrades += upgradeDelta;
             variables.Add("L", level.ToString());
-            variables.Add("LM", level.ToString());
+            variables.Add("LM", levelMax.ToString());
             variables.Add("N", upgrades.ToString());
             variables.Add("I", index.ToString());
             variables.Add("R", KCT_Utilities.BuildingUpgradeLevel(SpaceCenterFacility.ResearchAndDevelopment).ToString());


### PR DESCRIPTION
The variables "L" and "LM" in ParseBuildRateFormula() were assigned the same value.